### PR TITLE
#5: Multiline Swap

### DIFF
--- a/src/main/kotlin/de/rtrx/a/flow/FlowParts.kt
+++ b/src/main/kotlin/de/rtrx/a/flow/FlowParts.kt
@@ -174,7 +174,7 @@ class RedditReplyer @Inject constructor(
     override fun invoke(submission: Submission, reason: String): Pair<Comment, CommentReference> {
         val comment = submission.toReference(redditClient)
                 .reply(config[RedditSpec.scoring.commentBody].replace("%{Reason}",
-                        reason.take(config[RedditSpec.messages.unread.answerMaxCharacters])))
+                        reason.take(config[RedditSpec.messages.unread.answerMaxCharacters]).replace("\n\n","  \n")))
         return comment to comment.toReference(redditClient)
     }
 }


### PR DESCRIPTION
The spoiler-censoring function is failing because paragraphs in reddit don't work with a single spoiler tag. This is fixable by changing the double-newline paragraph separator with a two-space newline separator.

Adding a simple `replace()` method call to the outer call to put the comment response in resolves this issue in my tests.

Sample broken spoiler tag: [link](https://old.reddit.com/r/Unexpected/comments/jr184c/trying_to_catch_a_fish/gbqexln/)