### PR TITLE
Bugfix/12 remove leading whitespace

### DIFF
--- a/src/main/kotlin/de/rtrx/a/flow/FlowParts.kt
+++ b/src/main/kotlin/de/rtrx/a/flow/FlowParts.kt
@@ -175,7 +175,7 @@ class RedditReplyer @Inject constructor(
         val comment = submission.toReference(redditClient)
                 .reply(config[RedditSpec.scoring.commentBody].replace("%{Reason}",
                         //Prevents People from breaking the spoiler tag
-                        reason.take(config[RedditSpec.messages.unread.answerMaxCharacters]).replace("\n\n","  \n")))
+                        reason.take(config[RedditSpec.messages.unread.answerMaxCharacters]).replace("\n\n","  \n").trim()))
         return comment to comment.toReference(redditClient)
     }
 }


### PR DESCRIPTION
Fix for issue #12, where leading spaces in the answer break spoiler markdown.